### PR TITLE
Fix `no-turbo` build

### DIFF
--- a/app/[page]/page.tsx
+++ b/app/[page]/page.tsx
@@ -4,9 +4,9 @@ import path from 'path'
 import { MDXRemote } from 'next-mdx-remote/rsc'
 
 interface PageProps {
-  params: {
+  params: Promise<{
     page: string
-  }
+  }>
 }
 
 // Get all available MDX files for static generation
@@ -27,7 +27,7 @@ export async function generateStaticParams() {
 }
 
 export default async function DynamicPage({ params }: PageProps) {
-  const { page } = params
+  const { page } = await params
   
   try {
     // Read the MDX file


### PR DESCRIPTION
The deploy script uses the `yarn build:no-turbo` command. This version of the build process was experiencing an error where `params` is expected to be a Promise. This fixes that.