### PR TITLE
Make agenda vertical

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,7 +119,7 @@ export default function Home() {
               {Agenda.length === 0 ?
                 <p className="font-sans text-2xl text-center border-zinc-800 border p-6">Coming Soon</p>
               :
-                <div className="border border-zinc-800 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+                <div className="border border-zinc-800 grid grid-cols-1">
                   {Agenda.map((agendaItem, key) => (
                     <AgendaItem
                       time={agendaItem.time}

--- a/components/AgendaItem.tsx
+++ b/components/AgendaItem.tsx
@@ -9,27 +9,17 @@ export type AgendaEntry = {
 }
 
 export default function AgendaItem(props:AgendaEntry){
-    let classes = "font-sans flex flex-col gap-3 py-3 px-3 border border-zinc-800 min-h-100 justify-between"
+    let classes = "font-sans grid grid-cols-1 sm:grid-cols-2 gap-3 py-3 px-3 border border-zinc-800 justify-between"
 
-    if(props.type === "multi") classes += " sm:col-span-2"
+    if(props.type === "multi") classes += ""
 
     return(
         <div className={classes}>
-            <p className="font-bold">{props.time}</p>
-            {props.imgSrc && props.type === "image" ?
-            <Picture
-                src={props.imgSrc}
-                src2x={props.imgSrc}
-                alt=""
-            />
-            : ""}
-            {props.videoSrc && props.type === "video" ?
-            <video src={props.videoSrc} loop autoPlay muted></video>
-            : ""}
+            <p className="font-bold text-xl">{props.time}</p>
             <div className="flex flex-col gap-3">
                 {props.content.map((contentItem, key) => (
                     <div key={key}>
-                        <h3>{contentItem.title}</h3>
+                        <h3 className="text-xl">{contentItem.title}</h3>
                         {contentItem.speaker ?
                         <p className="text-zinc-400">{contentItem.speaker}</p>
                         : ""}


### PR DESCRIPTION
This PR makes the agenda vertical and also removes the pictures since I don't think we plan to sue them anymore.

### Samples at various screen sizes

![Screenshot 2025-10-30 at 12 54 45](https://github.com/user-attachments/assets/24e310c7-3e02-41e2-9d81-662c56163828)
<img width="1446" height="1902" alt="Screenshot 2025-10-30 at 12 55 04" src="https://github.com/user-attachments/assets/9a8c2738-652c-4ba5-9832-671589905eac" />
<img width="814" height="1914" alt="Screenshot 2025-10-30 at 12 55 17" src="https://github.com/user-attachments/assets/9b4c24aa-9c07-4352-9a25-2b838f586114" />
